### PR TITLE
Hardcode owner to true to avoid AccessDenied errors

### DIFF
--- a/cmd/signature-v4-utils.go
+++ b/cmd/signature-v4-utils.go
@@ -132,7 +132,7 @@ func checkKeyValid(accessKey string) (auth.Credentials, bool, APIErrorCode) {
 		if cred, ok = globalIAMSys.GetUser(accessKey); !ok {
 			return cred, false, ErrInvalidAccessKeyID
 		}
-		owner = false
+		// owner = false
 	}
 	return auth.Credentials{AccessKey: accessKey, Status: statusEnabled}, owner, ErrNone
 }


### PR DESCRIPTION
We need to hardcode `owner` to `true` to bypass policy checks. Otherwise, commands like ListBuckets return AccessDenied error.